### PR TITLE
API Level 11以上でテーマ参照失敗が発生しなくなるように style.xml を追加

### DIFF
--- a/MyTemplate/src/main/res/values-v11/style.xml
+++ b/MyTemplate/src/main/res/values-v11/style.xml
@@ -1,0 +1,11 @@
+<resources>
+
+    <!--
+        Base application theme for API 11+. This theme completely replaces
+        AppBaseTheme from res/values/styles.xml on API 11+ devices.
+    -->
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+        <!-- API 11 theme customizations can go here. -->
+    </style>
+
+</resources>

--- a/MyTemplate/src/main/res/values-v14/style.xml
+++ b/MyTemplate/src/main/res/values-v14/style.xml
@@ -1,0 +1,12 @@
+<resources>
+
+    <!--
+        Base application theme for API 14+. This theme completely replaces
+        AppBaseTheme from BOTH res/values/styles.xml and
+        res/values-v11/styles.xml on API 14+ devices.
+    -->
+    <style name="AppBaseTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+        <!-- API 14 theme customizations can go here. -->
+    </style>
+
+</resources>


### PR DESCRIPTION
values-v11やvalues-v14以下にて定義がない場合、values以下で定義をしていたとしても、AppBaseThemeとして標準のものが用いられるようです。

そのため、Honeycomb以降の端末では、ActionBarActivity とテーマの不一致が発生し、Activity起動時点で失敗しました。これを解決するため、明示的に values-v11/style.xml と values-v11/style.xml にて、AppBaseTheme を定義したところ、上記の問題が解消しました。

Android 4.1端末(SO-01E)、Android 4.3(Google I/O版Galaxy Nexus)にて、問題の発生と解決を確認しています。

取り込んでいただきますよう、お願いします。
