### PR TITLE
update gradle wrapper to 2.14.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,5 +51,5 @@ task clean(type: Delete) {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.14'
+    gradleVersion = '2.14.1'
 }


### PR DESCRIPTION
Gradle 2.14は[何かやらかした](https://docs.gradle.org/2.14.1/release-notes)らしいので、2.14.1にしてみました。
